### PR TITLE
Changed default dev port to 2918

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-LTI_DOMAIN="localhost:3000"
+LTI_DOMAIN="localhost:2918"
 NODE_ENV="development"
 ISS="canvas.instructure.com"
 CLIENT_ID="10000000000001"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm run dev
 ```
 
 This starts your app in development mode, rebuilding assets on file changes.
-Note that your tool url and domain will now be `localhost:3000` instead of the
+Note that your tool url and domain will now be `localhost:2918` instead of the
 deployed url and domain.
 
 ## Configuring with Canvas

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "postinstall": "remix setup node",
     "build": "cross-env NODE_ENV=production remix build",
-    "dev": "cross-env NODE_ENV=development remix dev",
+    "dev": "cross-env PORT=2918 NODE_ENV=development remix dev",
     "start": "cross-env NODE_ENV=production remix-serve build"
   }
 }


### PR DESCRIPTION
Changes the default port from the commonly-used 3000 to something more obscure to avoid conflicts.